### PR TITLE
Remove Intermediate Container Packaging Bug

### DIFF
--- a/src/engine/plugins/package_fastapi/package_fastapi.py
+++ b/src/engine/plugins/package_fastapi/package_fastapi.py
@@ -68,6 +68,8 @@ def package(
             "version": metadata.version,
         },
         tag=f"{metadata.name}-fastapi:{metadata.version}",
+        rm=True,
+        forcerm=True,
     )
 
     images["fastapi"] = image[0]

--- a/src/engine/plugins/package_streamlit/package_streamlit.py
+++ b/src/engine/plugins/package_streamlit/package_streamlit.py
@@ -68,6 +68,8 @@ def package(
             "version": metadata.version,
         },
         tag=f"{metadata.name}-streamlit:{metadata.version}",
+        rm=True,
+        forcerm=True,
     )
 
     images["streamlit"] = image[0]


### PR DESCRIPTION
## Summary

Fixes issues with orphaned containers being created when building images for both the `fastapi` and `streamlit` plugins. The default behavior of the `docker` CLI is different than the Python API.

## Testing

Package a fresh version of any package and ensure that there are not extra containers left in the `created` or `exited` state that did not exist prior to packaging.